### PR TITLE
Remove toJSON attribute from models in dashboard config controller

### DIFF
--- a/lib/configuration/hooks/dashboard/config/config.js
+++ b/lib/configuration/hooks/dashboard/config/config.js
@@ -56,6 +56,11 @@ module.exports = function * () {
     // Set the models.
     output.models = strapi.models;
 
+    // Delete `toJSON` attribute in every models.
+    _.forEach(output.models, function (model) {
+      delete model.attributes.toJSON;
+    });
+
     // Format `config.api` for multi templates models.
     _.forEach(strapi.api, function (api, key) {
       if (api.templates) {


### PR DESCRIPTION
Remove toJSON attribute from models in dashboard config controller