### PR TITLE
Use ES5 .bind() and ES6 arrow functions

### DIFF
--- a/lib/Strapi.js
+++ b/lib/Strapi.js
@@ -10,7 +10,6 @@ const events = require('events');
 const util = require('util');
 
 // Public node modules.
-const _ = require('lodash');
 const winston = require('winston');
 
 // Local dependencies.
@@ -38,15 +37,15 @@ function Strapi() {
   mixinAfter(this);
 
   // Bind `this` context for all `Strapi.prototype.*` methods.
-  this.load = _.bind(this.load, this);
-  this.start = _.bind(this.start, this);
-  this.stop = _.bind(this.stop, this);
-  this.restart = _.bind(this.restart, this);
-  this.initialize = _.bind(this.initialize, this);
-  this.exposeGlobals = _.bind(this.exposeGlobals, this);
-  this.runBootstrap = _.bind(this.runBootstrap, this);
-  this.isLocalStrapiValid = _.bind(this.isLocalStrapiValid, this);
-  this.isStrapiAppSync = _.bind(this.isStrapiAppSync, this);
+  this.load = this.load.bind(this);
+  this.start = this.start.bind(this);
+  this.stop = this.stop.bind(this);
+  this.restart = this.restart.bind(this);
+  this.initialize = this.initialize.bind(this);
+  this.exposeGlobals = this.exposeGlobals.bind(this);
+  this.runBootstrap = this.runBootstrap.bind(this);
+  this.isLocalStrapiValid = this.isLocalStrapiValid.bind(this);
+  this.isStrapiAppSync = this.isStrapiAppSync.bind(this);
 
   // Expose `koa`.
   this.server = require('koa');

--- a/lib/Strapi.js
+++ b/lib/Strapi.js
@@ -36,17 +36,6 @@ function Strapi() {
   // Mixin support for `Strapi.prototype.after()`.
   mixinAfter(this);
 
-  // Bind `this` context for all `Strapi.prototype.*` methods.
-  this.load = this.load.bind(this);
-  this.start = this.start.bind(this);
-  this.stop = this.stop.bind(this);
-  this.restart = this.restart.bind(this);
-  this.initialize = this.initialize.bind(this);
-  this.exposeGlobals = this.exposeGlobals.bind(this);
-  this.runBootstrap = this.runBootstrap.bind(this);
-  this.isLocalStrapiValid = this.isLocalStrapiValid.bind(this);
-  this.isStrapiAppSync = this.isStrapiAppSync.bind(this);
-
   // Expose `koa`.
   this.server = require('koa');
   this.app = require('koa')();

--- a/lib/load.js
+++ b/lib/load.js
@@ -17,7 +17,7 @@ const __initializeHooks = require('./private/loadHooks');
  * Load the Strapi instance
  */
 
-module.exports = function (strapi) {
+module.exports = strapi => {
   const Configuration = __Configuration(strapi);
   const initializeHooks = __initializeHooks(strapi);
 
@@ -80,13 +80,9 @@ module.exports = function (strapi) {
     }
 
     async.series([
-      function (cb) {
-        loadHookDefinitions(strapi.hooks, cb);
-      },
-      function (cb) {
-        initializeHooks(strapi.hooks, cb);
-      }
-    ], function (err) {
+      cb => loadHookDefinitions(strapi.hooks, cb),
+      cb => initializeHooks(strapi.hooks, cb)
+    ], err => {
       if (err) {
         return cb(err);
       }

--- a/lib/restart.js
+++ b/lib/restart.js
@@ -16,81 +16,73 @@ const async = require('async');
  * (useful for the Studio)
  */
 
-module.exports = function (cb) {
-  const self = this;
+module.exports = cb => {
 
   console.log();
 
   // Update the Strapi status (might be used
   // by the core or some hooks).
-  self.reloading = true;
+  this.reloading = true;
 
   // Async module loader to rebuild a
   // dictionary of the application.
   async.auto({
 
     // Rebuild the dictionaries.
-    dictionaries: function (cb) {
-      self.on('hook:_config:reloaded', function () {
-        self.on('hook:_api:reloaded', function () {
-          cb();
-        });
-
-        self.hooks._api.reload();
+    dictionaries: cb => {
+      this.on('hook:_config:reloaded', () => {
+        this.on('hook:_api:reloaded', () => cb());
+        this.hooks._api.reload();
       });
 
-      self.hooks._config.reload();
+      this.hooks._config.reload();
     }
   },
 
   // Callback.
-  function (err) {
+  err => {
 
     // Just in case there is an error.
     if (err) {
-      self.log.error('Impossible to reload the server');
-      self.log.error('Please restart the server manually');
-      self.stop();
+      this.log.error('Impossible to reload the server');
+      this.log.error('Please restart the server manually');
+      this.stop();
     }
 
     // Tell the application the framework is reloading
     // (might be used by some hooks).
-    self.reloading = true;
+    this.reloading = true;
 
     // Teardown Waterline adapters and
     // reload the Waterline ORM.
-    self.after('hook:waterline:reloaded', function () {
-      self.after('hook:router:reloaded', function () {
-        process.nextTick(function () {
-          cb();
-        });
+    this.after('hook:waterline:reloaded', () => {
+      this.after('hook:router:reloaded', () => {
+        process.nextTick(() => cb());
 
         // Update `strapi` status.
-        self.reloaded = true;
-        self.reloading = false;
+        this.reloaded = true;
+        this.reloading = false;
 
         // Finally inform the developer everything seems ok.
         if (cluster.isMaster && _.isPlainObject(strapi.config.reload) && !_.isEmpty(strapi.config.reload) && strapi.config.reload.workers < 1) {
-          self.log.info('Application\'s dictionnary updated');
-          self.log.warn('You still need to restart your server to fully enjoy changes...');
+          this.log.info('Application\'s dictionnary updated');
+          this.log.warn('You still need to restart your server to fully enjoy changes...');
         }
 
         // Kill every worker processes.
-        _.forEach(cluster.workers, function () {
-          process.kill(process.pid, 'SIGHUP');
-        });
+        _.forEach(cluster.workers, () => process.kill(process.pid, 'SIGHUP'));
 
         if (cluster.isMaster && _.isPlainObject(strapi.config.reload) && !_.isEmpty(strapi.config.reload) && strapi.config.reload.workers > 0) {
-          self.log.info('Application restarted');
+          this.log.info('Application restarted');
           console.log();
         }
       });
 
       // Reloading the router.
-      self.hooks.router.reload();
+      this.hooks.router.reload();
     });
 
     // Reloading the ORM.
-    self.hooks.waterline.reload();
+    this.hooks.waterline.reload();
   });
 };

--- a/lib/server.js
+++ b/lib/server.js
@@ -12,13 +12,6 @@ const Strapi = require('./Strapi');
  * (maintains backwards compatibility with constructor usage).
  */
 
-module.exports = strapiFactory;
-
-function strapiFactory() {
+module.exports = function () {
   return new Strapi();
-}
-
-// Backwards compatibility for Strapi singleton usage.
-const singleton = strapiFactory();
-strapiFactory.isLocalStrapiValid = singleton.isLocalStrapiValid.bind(singleton);
-strapiFactory.isStrapiAppSync = singleton.isStrapiAppSync.bind(singleton);
+};

--- a/lib/server.js
+++ b/lib/server.js
@@ -4,9 +4,6 @@
  * Module dependencies
  */
 
-// Public node modules.
-const _ = require('lodash');
-
 // Local dependencies.
 const Strapi = require('./Strapi');
 
@@ -23,5 +20,5 @@ function strapiFactory() {
 
 // Backwards compatibility for Strapi singleton usage.
 const singleton = strapiFactory();
-strapiFactory.isLocalStrapiValid = _.bind(singleton.isLocalStrapiValid, singleton);
-strapiFactory.isStrapiAppSync = _.bind(singleton.isStrapiAppSync, singleton);
+strapiFactory.isLocalStrapiValid = singleton.isLocalStrapiValid.bind(singleton);
+strapiFactory.isStrapiAppSync = singleton.isStrapiAppSync.bind(singleton);

--- a/lib/start.js
+++ b/lib/start.js
@@ -24,7 +24,7 @@ module.exports = function start(configOverride, cb) {
   // Callback is optional.
   cb = cb || function (err) {
     if (err) {
-      return this.log.error(err);
+      return self.log.error(err);
     }
   };
 

--- a/lib/start.js
+++ b/lib/start.js
@@ -4,6 +4,9 @@
  * Module dependencies
  */
 
+// Node.js core.
+const cluster = require('cluster');
+
 // Public node modules.
 const async = require('async');
 
@@ -28,5 +31,40 @@ module.exports = function start(configOverride, cb) {
   async.series([
     cb => self.load(configOverride, cb),
     this.initialize
-  ]);
+  ],
+
+  function strapiReady(err) {
+    if (err) {
+      return self.stop(function (errorStoppingStrapi) {
+        if (errorStoppingStrapi) {
+          self.log.error('When trying to stop the application as a result of a failed start');
+          self.log.error(errorStoppingStrapi);
+        }
+        cb(err);
+      });
+    }
+
+    // Log some server info.
+    if (cluster.isMaster) {
+      self.log.info('Server started in ' + self.config.appPath);
+      self.log.info('Your server is running at ' + self.config.url);
+      self.log.debug('Time: ' + new Date());
+      self.log.debug('Environment: ' + self.config.environment);
+      self.log.debug('Process PID: ' + process.pid);
+      self.log.debug('Cluster: master');
+      self.log.info('To shut down your server, press <CTRL> + C at any time');
+    } else {
+      self.log.warn('New worker starting...');
+      self.log.debug('Process PID: ' + process.pid);
+      self.log.debug('Cluster: worker #' + cluster.worker.id);
+    }
+
+    // Blank log to give some space.
+    console.log();
+
+    // Emit an event when Strapi has started.
+    self.emit('started');
+    self.started = true;
+    return cb(null, self);
+  });
 };

--- a/lib/start.js
+++ b/lib/start.js
@@ -24,15 +24,13 @@ module.exports = function start(configOverride, cb) {
   // Callback is optional.
   cb = cb || function (err) {
     if (err) {
-      return self.log.error(err);
+      return this.log.error(err);
     }
   };
 
   async.series([
-    function (cb) {
-      self.load(configOverride, cb);
-    },
-    self.initialize
+    cb => self.load(configOverride, cb),
+    this.initialize
   ],
 
   function strapiReady(err) {

--- a/lib/start.js
+++ b/lib/start.js
@@ -4,9 +4,6 @@
  * Module dependencies
  */
 
-// Node.js core.
-const cluster = require('cluster');
-
 // Public node modules.
 const async = require('async');
 
@@ -31,40 +28,5 @@ module.exports = function start(configOverride, cb) {
   async.series([
     cb => self.load(configOverride, cb),
     this.initialize
-  ],
-
-  function strapiReady(err) {
-    if (err) {
-      return self.stop(function (errorStoppingStrapi) {
-        if (errorStoppingStrapi) {
-          self.log.error('When trying to stop the application as a result of a failed start');
-          self.log.error(errorStoppingStrapi);
-        }
-        cb(err);
-      });
-    }
-
-    // Log some server info.
-    if (cluster.isMaster) {
-      self.log.info('Server started in ' + self.config.appPath);
-      self.log.info('Your server is running at ' + self.config.url);
-      self.log.debug('Time: ' + new Date());
-      self.log.debug('Environment: ' + self.config.environment);
-      self.log.debug('Process PID: ' + process.pid);
-      self.log.debug('Cluster: master');
-      self.log.info('To shut down your server, press <CTRL> + C at any time');
-    } else {
-      self.log.warn('New worker starting...');
-      self.log.debug('Process PID: ' + process.pid);
-      self.log.debug('Cluster: worker #' + cluster.worker.id);
-    }
-
-    // Blank log to give some space.
-    console.log();
-
-    // Emit an event when Strapi has started.
-    self.emit('started');
-    self.started = true;
-    return cb(null, self);
-  });
+  ]);
 };

--- a/lib/stop.js
+++ b/lib/stop.js
@@ -12,15 +12,14 @@
  */
 
 module.exports = function stop() {
-  const self = this;
 
-  // Flag `self._exiting` as soon as the application has begun to shutdown.
+  // Flag `this._exiting` as soon as the application has begun to shutdown.
   // This may be used by hooks and other parts of core.
-  self._exiting = true;
+  this._exiting = true;
 
   // Exit the REPL.
   process.exit(0);
 
   // Emit a `stop` event.
-  self.emit('stop');
+  this.emit('stop');
 };


### PR DESCRIPTION
With ES5 native `Function.bind()` you can bind `this` context without using `lodash`

With ES6 arrow functions, the context `this` pass through the call chain, so there is no need to specify a reference to `this`.

**Note**:

Regarding lines https://github.com/wistityhq/strapi/blob/master/lib/Strapi.js#L41-L49 I don't think you even have to bind those functions, since they are already part of the `Strapi.prototype` when `Strapi` is called with `new`, all those functions will use `this` as the instance of `Strapi` by default.

**Note 2**:

Is this funciton used somewhere? https://github.com/wistityhq/strapi/blob/master/lib/start.js#L38