### PR TITLE
Add `test` env config to `strapi-generate-new`

### DIFF
--- a/packages/strapi-generate-new/files/config/environments/test/authentication.json
+++ b/packages/strapi-generate-new/files/config/environments/test/authentication.json
@@ -1,0 +1,5 @@
+{
+  "authentication": {
+    
+  }
+}

--- a/packages/strapi-generate-new/files/config/environments/test/databases.json
+++ b/packages/strapi-generate-new/files/config/environments/test/databases.json
@@ -1,0 +1,17 @@
+{
+  "defaultConnection": "default",
+  "connections": {
+    "default": {
+      "client": "sqlite3",
+      "debug": false,
+      "acquireConnectionTimeout": 60000,
+      "useNullAsDefault": true,
+      "connection": {
+        "filename": "./data/db.sqlite"
+      },
+      "migrations": {
+        "tableName": "migrations"
+      }
+    }
+  }
+}

--- a/packages/strapi-generate-new/files/config/environments/test/security.json
+++ b/packages/strapi-generate-new/files/config/environments/test/security.json
@@ -1,0 +1,47 @@
+{
+  "session": {
+    "key": "myApp",
+    "secretKeys": [
+      "mySecretKey1"
+    ],
+    "maxAge": 86400000
+  },
+  "csrf": false,
+  "csp": false,
+  "p3p": false,
+  "hsts": {
+    "maxAge": 31536000,
+    "includeSubDomains": true
+  },
+  "xframe": "SAMEORIGIN",
+  "xssProtection": false,
+  "cors": {
+    "origin": "http://studio.strapi.io",
+    "expose": [
+      "WWW-Authenticate",
+      "Server-Authorization"
+    ],
+    "maxAge": 31536000,
+    "credentials": true,
+    "methods": [
+      "GET",
+      "POST",
+      "PUT",
+      "PATCH",
+      "DELETE",
+      "OPTIONS",
+      "HEAD"
+    ],
+    "headers": [
+      "Content-Type",
+      "Authorization",
+      "StudioToken"
+    ]
+  },
+  "ssl": false,
+  "ip": {
+    "whiteList": [],
+    "blackList": []
+  },
+  "proxy": false
+}

--- a/packages/strapi-generate-new/files/config/environments/test/server.json
+++ b/packages/strapi-generate-new/files/config/environments/test/server.json
@@ -1,0 +1,23 @@
+{
+  "host": "localhost",
+  "port": 1337,
+  "frontendUrl": "",
+  "reload": {
+    "timeout": 1000,
+    "workers": 0
+  },
+  "logger": true,
+  "parser": {
+    "encode": "utf-8",
+    "formLimit": "56kb",
+    "jsonLimit": "1mb",
+    "strict": true,
+    "extendTypes": {
+      "json": [
+        "application/x-javascript"
+      ]
+    }
+  },
+  "gzip": true,
+  "responseTime": true
+}


### PR DESCRIPTION
This PR adds `test` environment configuration files to `strapi-generate-new` package. This way, a `strapi new` command will generate an app with test configuration files.

Ref. #117.